### PR TITLE
Revert "Update chart cilium from 1.14.6 to 1.15.0"

### DIFF
--- a/cluster/core/cilium/helmrelease.yaml
+++ b/cluster/core/cilium/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: 1.15.0
+      version: 1.14.6
       sourceRef:
         kind: HelmRepository
         name: cilium-charts

--- a/talos/cni/kustomization.yaml
+++ b/talos/cni/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 helmCharts:
   - name: cilium
     repo: https://helm.cilium.io/
-    version: 1.15.0
+    version: 1.14.6
     releaseName: cilium
     namespace: kube-system
     valuesFile: values.yaml


### PR DESCRIPTION
This reverts commit aebb35fd6650e415bc5c59f5171aa6d93aa7dd27.

possibly broke webhooks