### PR TITLE
add envoy-gateway, migrate echo-server to Gateway API HTTPRoute

### DIFF
--- a/cluster/apps/ingress/echo-server/helmrelease.yaml
+++ b/cluster/apps/ingress/echo-server/helmrelease.yaml
@@ -9,7 +9,7 @@ spec:
   chart:
     spec:
       chart: app-template
-      version: 4.6.2
+      version: 5.0.1
       sourceRef:
         kind: HelmRepository
         name: bjw-s-charts
@@ -27,9 +27,9 @@ spec:
     defaultPodOptions:
       runtimeClassName: gvisor
     controllers:
-      echo-server:
+      main:
         containers:
-          app:
+          main:
             image:
               repository: docker.io/jmalloc/echo-server
               tag: v0.3.7
@@ -40,7 +40,7 @@ spec:
               limits:
                 memory: 50Mi
             probes:
-              liveness: &probe
+              liveness:
                 enabled: true
                 custom: true
                 spec:
@@ -50,27 +50,30 @@ spec:
                   periodSeconds: 10
                   timeoutSeconds: 1
                   failureThreshold: 3
-              readiness: *probe
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8080
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
               startup:
                 enabled: false
     service:
-      app:
-        controller: echo-server
+      main:
+        controller: main
         ports:
           http:
             port: 8080
-    ingress:
+    route:
       main:
         enabled: true
-        hosts:
-          - host: &host echo.${S_HOMEPROD_DOMAIN}
-            paths:
-              - path: /
-                pathType: Prefix
-                service:
-                  identifier: app
-                  port: http
-        tls:
-          - hosts:
-              - *host
-        className: nginx
+        kind: HTTPRoute
+        hostnames:
+          - "echo.${S_HOMEPROD_DOMAIN}"
+        parentRefs:
+          - name: envoy-gateway
+            namespace: ingress

--- a/cluster/apps/ingress/envoy-gateway/gateway-class.yaml
+++ b/cluster/apps/ingress/envoy-gateway/gateway-class.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: envoy-gateway
+spec:
+  controllerName: gateway.envoyproxy.io/controller

--- a/cluster/apps/ingress/envoy-gateway/gateway.yaml
+++ b/cluster/apps/ingress/envoy-gateway/gateway.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: envoy-gateway
+  namespace: ingress
+spec:
+  gatewayClassName: envoy-gateway
+  listeners:
+    - name: https
+      port: 443
+      protocol: HTTPS
+      hostname: "*.${S_HOMEPROD_DOMAIN}"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: homeprod-domain-tls
+    - name: http
+      port: 80
+      protocol: HTTP
+      hostname: "*.${S_HOMEPROD_DOMAIN}"

--- a/cluster/apps/ingress/envoy-gateway/helmrelease.yaml
+++ b/cluster/apps/ingress/envoy-gateway/helmrelease.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: envoy-gateway
+  namespace: ingress
+spec:
+  interval: 15m
+  chartRef:
+    kind: OCIRepository
+    name: envoy-gateway
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  driftDetection:
+    mode: enabled
+  dependsOn:
+    - name: cert-manager
+      namespace: ingress

--- a/cluster/apps/ingress/envoy-gateway/kustomization.yaml
+++ b/cluster/apps/ingress/envoy-gateway/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: ingress
+resources:
+  - ocirepository.yaml
+  - helmrelease.yaml
+  - gateway-class.yaml
+  - gateway.yaml

--- a/cluster/apps/ingress/envoy-gateway/ocirepository.yaml
+++ b/cluster/apps/ingress/envoy-gateway/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: envoy-gateway
+  namespace: ingress
+spec:
+  interval: 1h
+  url: oci://docker.io/envoyproxy/gateway-helm
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.8.1

--- a/cluster/apps/ingress/kustomization.yaml
+++ b/cluster/apps/ingress/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - namespace.yaml
   - cert-manager
   - ingress-nginx
+  - envoy-gateway
   - echo-server
 #  - static-routes


### PR DESCRIPTION
Phase 1 of nginx-ingress to Envoy Gateway migration:
- Install Envoy Gateway v1.8.1 via OCI Helm chart (Flux OCIRepository)
- Create GatewayClass and Gateway with TLS (reuses homeprod-domain-tls)
- Upgrade echo-server to app-template v5.0.1, replace nginx Ingress with native HTTPRoute targeting envoy-gateway
- Both gateways coexist; no DNS changes yet