### PR TITLE
fix(multus): migrate from angelnu chart to bjw-s OCI chart

### DIFF
--- a/cluster/apps/networking/multus/app/helmrelease.yaml
+++ b/cluster/apps/networking/multus/app/helmrelease.yaml
@@ -5,16 +5,10 @@ metadata:
   name: multus
   namespace: networking
 spec:
-  interval: 15m
-  chart:
-    spec:
-      chart: multus
-      version: 7.0.0
-      sourceRef:
-        kind: HelmRepository
-        name: angelnu-charts
-        namespace: flux-system
-      interval: 15m
+  chartRef:
+    kind: OCIRepository
+    name: multus
+  interval: 30m
   install:
     createNamespace: true
     remediation:
@@ -25,15 +19,6 @@ spec:
   driftDetection:
     mode: enabled
   values:
-    image:
-      repository: ghcr.io/k8snetworkplumbingwg/multus-cni
-      tag: v4.2.4-thick
     cni:
-      image:
-        repository: ghcr.io/angelnu/cni-plugins
-        tag: 1.8.0
-      paths:
-        config: /etc/cni/net.d
-        bin: /opt/cni/bin
-    hostPaths:
-      netns: /var/run/netns
+      netPath: /etc/cni/net.d
+      binPath: /opt/cni/bin

--- a/cluster/apps/networking/multus/app/kustomization.yaml
+++ b/cluster/apps/networking/multus/app/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helmrelease.yaml
+  - ocirepository.yaml

--- a/cluster/apps/networking/multus/app/ocirepository.yaml
+++ b/cluster/apps/networking/multus/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: multus
+  namespace: networking
+spec:
+  interval: 1h
+  url: oci://ghcr.io/bjw-s-labs/helm/multus
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.3.2


### PR DESCRIPTION
Replace angelnu/multus (HelmRepository) with bjw-s-labs/multus (OCIRepository). Resolves service account ambiguity error.

- chart: oci://ghcr.io/bjw-s-labs/helm/multus@1.3.2
- values formatted for new chart schema