### PR TITLE
fix: enable chart-managed CRDs for cert-manager and volsync

### DIFF
--- a/cluster/apps/ingress/cert-manager/helmrelease.yaml
+++ b/cluster/apps/ingress/cert-manager/helmrelease.yaml
@@ -24,7 +24,8 @@ spec:
   driftDetection:
     mode: enabled
   values:
-    installCRDs: false
+    crds:
+      enabled: true
     extraArgs:
       - --dns01-recursive-nameservers=1.1.1.1:53,9.9.9.9:53
       - --dns01-recursive-nameservers-only

--- a/cluster/apps/utils/volsync/app/helmrelease.yaml
+++ b/cluster/apps/utils/volsync/app/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
   driftDetection:
     mode: enabled
   values:
-    manageCRDs: false
+    manageCRDs: true
     # TODO get monitoring working
     metrics:
       disableAuth: true


### PR DESCRIPTION
cert-manager: installCRDs:false → crds.enabled:true
volsync: manageCRDs:false → true

Charts now manage their own CRDs via Helm hooks, removing the dependency on the separate CRD bootstrap extraction.