### PR TITLE
rook-ceph: install required CSI drivers chart

### DIFF
--- a/cluster/core/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/cluster/core/rook-ceph/csi-drivers/helmrelease.yaml
@@ -27,22 +27,14 @@ spec:
         clusterName: rook-ceph
         imageSet:
           name: rook-csi-operator-image-set-configmap
-        nodePlugin:
-          priorityClassName: system-node-critical
-        controllerPlugin:
-          priorityClassName: system-cluster-critical
     drivers:
       rbd:
         enabled: true
         name: rook-ceph.rbd.csi.ceph.com
         snapshotPolicy: volumeSnapshot
       cephfs:
-        enabled: true
-        name: rook-ceph.cephfs.csi.ceph.com
-        snapshotPolicy: volumeGroupSnapshot
+        enabled: false
       nfs:
         enabled: false
-        name: rook-ceph.nfs.csi.ceph.com
       nvmeof:
         enabled: false
-        name: rook-ceph.nvmeof.csi.ceph.com

--- a/cluster/core/rook-ceph/csi-drivers/helmrelease.yaml
+++ b/cluster/core/rook-ceph/csi-drivers/helmrelease.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ceph-csi-drivers
+  namespace: rook-ceph
+spec:
+  interval: 15m
+  chartRef:
+    kind: OCIRepository
+    name: ceph-csi-drivers
+  dependsOn:
+    - name: rook-ceph-operator
+      namespace: rook-ceph
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  driftDetection:
+    mode: enabled
+  values:
+    operatorConfig:
+      namespace: rook-ceph
+      driverSpecDefaults:
+        clusterName: rook-ceph
+        imageSet:
+          name: rook-csi-operator-image-set-configmap
+        nodePlugin:
+          priorityClassName: system-node-critical
+        controllerPlugin:
+          priorityClassName: system-cluster-critical
+    drivers:
+      rbd:
+        enabled: true
+        name: rook-ceph.rbd.csi.ceph.com
+        snapshotPolicy: volumeSnapshot
+      cephfs:
+        enabled: true
+        name: rook-ceph.cephfs.csi.ceph.com
+        snapshotPolicy: volumeGroupSnapshot
+      nfs:
+        enabled: false
+        name: rook-ceph.nfs.csi.ceph.com
+      nvmeof:
+        enabled: false
+        name: rook-ceph.nvmeof.csi.ceph.com

--- a/cluster/core/rook-ceph/csi-drivers/kustomization.yaml
+++ b/cluster/core/rook-ceph/csi-drivers/kustomization.yaml
@@ -2,7 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yaml
-  - operator
-  - csi-drivers
-  - cluster
+  - ocirepository.yaml
+  - helmrelease.yaml

--- a/cluster/core/rook-ceph/csi-drivers/ocirepository.yaml
+++ b/cluster/core/rook-ceph/csi-drivers/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ceph-csi-drivers
+  namespace: rook-ceph
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.0.4
+  url: oci://ghcr.io/home-operations/charts-mirror/ceph-csi-drivers


### PR DESCRIPTION
Rook v1.20 moved CSI driver configuration and RBAC into the separate ceph-csi-drivers chart. Without it, the CSI operator created workloads that referenced missing service accounts, leaving all RBD and CephFS plugins at zero replicas and blocking PVC workloads after the Talos rollout.

Install the v1.0.4 chart from the OCI mirror with Rook-compatible driver names and snapshot policies.